### PR TITLE
[DRAFT] Oracle pool warnings

### DIFF
--- a/pools/index.json
+++ b/pools/index.json
@@ -18,6 +18,10 @@
             "warning": {
                 "text": "This pool leverages an external oracle to price the underlying assets. It is highly experimental and should be used at your own risk. Please read through the \"Pool risks\" before adding liquidity to this pool.",
                 "type": "error"
+            },
+            "addLiquidityWarning": {
+                "text": "This pool leverages an external oracle to price the underlying assets. It is highly experimental and should be used at your own risk.",
+                "type": "error"
             }
         }
     }

--- a/pools/index.json
+++ b/pools/index.json
@@ -23,7 +23,7 @@
                 "text": "This pool leverages an external oracle to price the underlying assets. It is highly experimental and should be used at your own risk.",
                 "type": "error"
             },
-            "enableAddLiquidity": true
+            "allowAddLiquidity": true
         }
     }
 }

--- a/pools/index.json
+++ b/pools/index.json
@@ -22,7 +22,8 @@
             "addLiquidityWarning": {
                 "text": "This pool leverages an external oracle to price the underlying assets. It is highly experimental and should be used at your own risk.",
                 "type": "error"
-            }
+            },
+            "enableAddLiquidity": true
         }
     }
 }

--- a/pools/index.json
+++ b/pools/index.json
@@ -16,7 +16,7 @@
         },
         "0xcb80b1a9e7b319a4c5ec6b0666967ca1e309e40f": {
             "warning": {
-                "text": "This pool leverages an external oracle to price the underlying assets. It is highly experimental and should be used at your own risk. Please read through the \"Pool risks\" below before adding liquidity to this pool.",
+                "text": "This pool leverages an external oracle to price the underlying assets. It is highly experimental and should be used at your own risk. Please read through the \"Pool risks\" before adding liquidity to this pool.",
                 "type": "error"
             }
         }

--- a/pools/index.json
+++ b/pools/index.json
@@ -13,6 +13,12 @@
     "8453": {
         "0x4147d8aeecb75bc9f5c973c3b73d2dfc4dcce131": {
             "description": "This boosted pool is powered by 1) the Seamless USDC Vault on Morpho, which earns a base yield plus MORPHO and SEAM emissions and 2) sUSDS (Sky Savings Rate)"
+        },
+        "0xcb80b1a9e7b319a4c5ec6b0666967ca1e309e40f": {
+            "warning": {
+                "text": "This pool leverages an external oracle to price the underlying assets. It is highly experimental and should be used at your own risk.",
+                "type": "error"
+            }
         }
     }
 }

--- a/pools/index.json
+++ b/pools/index.json
@@ -16,7 +16,7 @@
         },
         "0xcb80b1a9e7b319a4c5ec6b0666967ca1e309e40f": {
             "warning": {
-                "text": "This pool leverages an external oracle to price the underlying assets. It is highly experimental and should be used at your own risk.",
+                "text": "This pool leverages an external oracle to price the underlying assets. It is highly experimental and should be used at your own risk. Please read through the \"Pool risks\" below before adding liquidity to this pool.",
                 "type": "error"
             }
         }


### PR DESCRIPTION
Add support for the following fields on the pool:

```javascript
warning: {text: string, type: AlertStatus},
addLiquidityWarning: {text: string, type: AlertStatus},
allowAddLiquidity: boolean
```

The goal here is to allow the maxis to provide contextual warnings for specific pools and enable add liquidity for specific pools that are not currently allowed.