### PR TITLE
Update Pareto Hyperlink

### DIFF
--- a/pools/tags/index.json
+++ b/pools/tags/index.json
@@ -28,7 +28,7 @@
         "name": "Pareto Efficiency Points",
         "description": "Receives Pareto Efficiency points",
         "value": "3",
-        "url": "https://pareto.credit/",
+        "url": "https://app.pareto.credit/points",
         "icon": "pareto.svg",
         "pools": ["0x114907c2a07978c38ebb9f9f6a5261a846b79521"]
     },


### PR DESCRIPTION
As per Pareto request, change "Learn More" Hyperlink
![image](https://github.com/user-attachments/assets/c96b1eac-a6b4-4335-ab41-b2c348ac7e58)
